### PR TITLE
Process SQL comment lines

### DIFF
--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -210,6 +210,8 @@ class Query(object):
                 line = line.strip()
                 if line.startswith('#'):
                     continue
+                elif line.startswith('--'):
+                    continue
                 
                 sqlFragments = line.split(';')
                 if len(sqlFragments) == 1:


### PR DESCRIPTION
In case that SQL script contains comment lines beginning with '--'
The Keyword fails due to emty SQL statement.
Patch ignores such lines from further processing
