### PR TITLE
Correct imports to work with any module

### DIFF
--- a/src/DatabaseLibrary/connection_manager.py
+++ b/src/DatabaseLibrary/connection_manager.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import importlib
+
 import ConfigParser
 from robot.api import logger
 
@@ -71,7 +73,7 @@ class ConnectionManager(object):
 
         self.db_api_module_name = dbapiModuleName
 
-        db_api_2 = __import__(dbapiModuleName)
+        db_api_2 = importlib.import_module(dbapiModuleName)
         if dbapiModuleName in ["MySQLdb", "pymysql"]:
             dbPort = dbPort or 3306
             logger.debug ('Connecting using : %s.connect(db=%s, user=%s, passwd=%s, host=%s, port=%s) ' % (dbapiModuleName, dbName, dbUsername, dbPassword, dbHost, dbPort))
@@ -104,7 +106,7 @@ class ConnectionManager(object):
         | # for JayDeBeApi |
         | Connect To Database Using Custom Params | JayDeBeApi | 'oracle.jdbc.driver.OracleDriver', 'my_db_test', 'system', 's3cr3t' |
         """
-        db_api_2 = __import__(dbapiModuleName)
+        db_api_2 = importlib.import_module(dbapiModuleName)
 
         db_connect_string = 'db_api_2.connect(%s)' % db_connect_string
 


### PR DESCRIPTION
Behavior  with `__import__` document here: http://stackoverflow.com/q/19044096/1695680
shows that this library will not work with the official `mysql-connector-python` package from oracle/mysql

The problem: requesting the connector `mysql.connector` passes the string `mysql.connector` to `__import__` which returns the `mysql` module, not the `mysql.connector` module. Obviously the `mysql` module does not have a `connect` method and fails.

Documented on the same SO link, http://stackoverflow.com/a/19053713/1695680 using the recommended `importlib` instead of the deprecated `__import__` resolves (avoids) this problem entirely.

I tested this with a simple RF script to execute a couple queries. With both the already-working `pymysql` connector, and with the previously non-working `mysql.connector` connector, the test passed.