### PR TITLE
Add Call Stored Procedure keyword

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyMySQL==0.7.4
-psycopg2==2.6.1
-robotframework==3.0
+#PyMySQL==0.7.4
+#psycopg2==2.6.1
+robotframework>=3.0

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -285,12 +285,12 @@ class Query(object):
         """
         cur = None
         try:
-            cur = self._dbconnection.cursor()
+            cur = self._dbconnection.cursor(as_dict=True)
             spName = spName.encode('ascii', 'ignore')
             logger.info ('Executing : Query  |  %s  |  %s ' % (spName, spParams))
-            allRows = cur.callproc(spName, (spParams))
-            self._dbconnection.commit()
-            return allRows
+            cur.callproc(spName, (spParams))
+            retVal = self._dbconnection.commit()
+            return retVal
         finally :
             if cur :
                 self._dbconnection.rollback()

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -268,7 +268,7 @@ class Query(object):
             if cur:
                 self._dbconnection.rollback()
 
-    def call_stored_procedure(self, spName, spParams):
+    def call_stored_procedure_dead(self, spName, spParams):
         """
         Uses the inputs of `spName` and 'spParams' to call a stored procedure
 
@@ -297,7 +297,7 @@ class Query(object):
             if cur :
                 self._dbconnection.rollback()
 
-    def call_stored_procedure_with_return(self, spName, spParams):
+    def call_stored_procedure(self, spName, spParams):
         """
         Uses the inputs of `spName` and 'spParams' to call a stored procedure
 
@@ -305,27 +305,28 @@ class Query(object):
         spParams should be a List of the parameters being sent in.
 
         |  @{ParamList} =  |  Create List  |  FirstParam  |  SecondParam  |  ThirdParam
-        |  @{QueryResults} =  |  Call Stored Procedure With Return  |  DBName.SchemaName.StoredProcName  |  List of Parameters
+        |  @{QueryResults} =  |  Call Stored Procedure  |  DBName.SchemaName.StoredProcName  |  List of Parameters
 
         |  @{ParamList} =  |  Create List  |  Testing  |  ${56789}  |  LastName
         |  Set Test Variable  |  ${SPName} =   |  DBTest.DBSchema.MyStoredProc
-        |  @{QueryResults} =  |  Call Stored Procedure With Return  |  ${SPName}  |  ${ParamList}
+        |  @{QueryResults} =  |  Call Stored Procedure  |  ${SPName}  |  ${ParamList}
         |  Log Many  |  ${QueryResults}
         """
         cur = None
         try:
             cur = self._dbconnection.cursor(as_dict=False)
             spName = spName.encode('ascii', 'ignore')
-            logger.info ('Executing : Call Stored Procedure With Return  |  %s  |  %s ' % (spName, spParams))
+            logger.info ('Executing : Call Stored Procedure  |  %s  |  %s ' % (spName, spParams))
             #retVal = cur.callproc(spName, (spParams))
             cur.callproc(spName, (spParams))
-            #cur.nextset()
+            cur.nextset()
             #self._dbconnection.commit()
             #logger.info ('retVal is  %s ' % (retVal))
             retVal=list()
             for row in cur:
                 #logger.info ( ' %s ' % (row))
                 retVal.append(row)
+            self._dbconnection.commit()
             return retVal
         finally :
             if cur :

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -268,26 +268,21 @@ class Query(object):
             if cur:
                 self._dbconnection.rollback()
 
-    def call_stored_procedure(self, spName, spParams):
+    def call_stored_procedure(self, spName, spParams=[]):
         """
         Uses the inputs of `spName` and 'spParams' to call a stored procedure
 
         spName should be the stored procedure name itself
-        spParams should be a List of the parameters being sent in.
+        spParams [Optional] should be a List of the parameters being sent in.  The list can be one or multiple items.
+
+        The return from this keyword will always be a list.
 
         |  @{ParamList} =  |  Create List  |  FirstParam  |  SecondParam  |  ThirdParam
         |  @{QueryResults} =  |  Call Stored Procedure  |  DBName.SchemaName.StoredProcName  |  List of Parameters
 
-        |  @{ParamList} =  |  Create List  |  Testing  |  ${56789}  |  LastName
+        |  @{ParamList} =  |  Create List  |  Testing  |  LastName
         |  Set Test Variable  |  ${SPName} =   |  DBTest.DBSchema.MyStoredProc
         |  @{QueryResults} =  |  Call Stored Procedure  |  ${SPName}  |  ${ParamList}
-        |  Log List  |  @{QueryResults}
-
-        Note: that the spParams is required to be passed in right now, even if it just an empty list.  In the following
-        example, the Stored Procedure does not accept any parameters.
-
-        |  @{ParamList} =  |  Create List
-        |  @{QueryResults} =  |  Call Stored Procedure  |  DBTest.DBSchema.NoParamsStoredProc  |  ${ParamList}
         |  Log List  |  @{QueryResults}
 
         """

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -268,35 +268,6 @@ class Query(object):
             if cur:
                 self._dbconnection.rollback()
 
-    def call_stored_procedure_dead(self, spName, spParams):
-        """
-        Uses the inputs of `spName` and 'spParams' to call a stored procedure
-
-        spName should be the stored procedure name itself
-        spParams should be a List of the parameters being sent in.
-
-        |  @{ParamList} =  |  Create List  |  FirstParam  |  SecondParam  |  ThirdParam
-        |  @{QueryResults} =  |  Call Stored Procedure  |  DBName.SchemaName.StoredProcName  |  List of Parameters
-
-        |  @{ParamList} =  |  Create List  |  Testing  |  ${56789}  |  LastName
-        |  Set Test Variable  |  ${SPName} =   |  DBTest.DBSchema.MyStoredProc
-        |  @{QueryResults} =  |  Call Stored Procedure  |  ${SPName}  |  ${ParamList}
-        |  Log Many  |  ${QueryResults}
-        """
-        cur = None
-        try:
-            cur = self._dbconnection.cursor(as_dict=True)
-            spName = spName.encode('ascii', 'ignore')
-            logger.info ('Executing : Call Stored Procedure  |  %s  |  %s ' % (spName, spParams))
-            #retVal = cur.callproc(spName, (spParams))
-            cur.callproc(spName, (spParams))
-            retVal = cur.nextset()
-            self._dbconnection.commit()
-            return retVal
-        finally :
-            if cur :
-                self._dbconnection.rollback()
-
     def call_stored_procedure(self, spName, spParams):
         """
         Uses the inputs of `spName` and 'spParams' to call a stored procedure
@@ -310,18 +281,15 @@ class Query(object):
         |  @{ParamList} =  |  Create List  |  Testing  |  ${56789}  |  LastName
         |  Set Test Variable  |  ${SPName} =   |  DBTest.DBSchema.MyStoredProc
         |  @{QueryResults} =  |  Call Stored Procedure  |  ${SPName}  |  ${ParamList}
-        |  Log Many  |  ${QueryResults}
+        |  Log List  |  @{QueryResults}
         """
         cur = None
         try:
             cur = self._dbconnection.cursor(as_dict=False)
             spName = spName.encode('ascii', 'ignore')
             logger.info ('Executing : Call Stored Procedure  |  %s  |  %s ' % (spName, spParams))
-            #retVal = cur.callproc(spName, (spParams))
             cur.callproc(spName, (spParams))
             cur.nextset()
-            #self._dbconnection.commit()
-            #logger.info ('retVal is  %s ' % (retVal))
             retVal=list()
             for row in cur:
                 #logger.info ( ' %s ' % (row))

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -271,6 +271,17 @@ class Query(object):
     def call_stored_procedure(self, spName, spParams):
         """
         Uses the inputs of `spName` and 'spParams' to call a stored procedure
+
+        spName should be the stored procedure name itself
+        spParams should be a List of the parameters being sent in.
+
+        |  @{ParamList} =  |  Create List  |  FirstParam  |  SecondParam  |  ThirdParam
+        |  @{QueryResults} =  |  Call Stored Procedure  |  DBName.SchemaName.StoredProcName  |  List of Parameters
+
+        |  @{ParamList} =  |  Create List  |  Testing  |  ${56789}  |  LastName
+        |  Set Test Variable  |  ${SPName} =   |  DBTest.DBSchema.MyStoredProc
+        |  @{QueryResults} =  |  Call Stored Procedure  |  ${SPName}  |  ${ParamList}
+        |  Log Many  |  ${QueryResults}
         """
         cur = None
         try:

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -268,7 +268,7 @@ class Query(object):
             if cur:
                 self._dbconnection.rollback()
 
-    def call_stored_procedure(self, spName, spParams=[]):
+    def call_stored_procedure(self, spName, spParams=None):
         """
         Uses the inputs of `spName` and 'spParams' to call a stored procedure
 
@@ -286,6 +286,8 @@ class Query(object):
         |  Log List  |  @{QueryResults}
 
         """
+        if spParams is None:
+            spParams = []
         cur = None
         try:
             cur = self._dbconnection.cursor(as_dict=False)

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -297,6 +297,39 @@ class Query(object):
             if cur :
                 self._dbconnection.rollback()
 
+    def call_stored_procedure_with_return(self, spName, spParams):
+        """
+        Uses the inputs of `spName` and 'spParams' to call a stored procedure
+
+        spName should be the stored procedure name itself
+        spParams should be a List of the parameters being sent in.
+
+        |  @{ParamList} =  |  Create List  |  FirstParam  |  SecondParam  |  ThirdParam
+        |  @{QueryResults} =  |  Call Stored Procedure With Return  |  DBName.SchemaName.StoredProcName  |  List of Parameters
+
+        |  @{ParamList} =  |  Create List  |  Testing  |  ${56789}  |  LastName
+        |  Set Test Variable  |  ${SPName} =   |  DBTest.DBSchema.MyStoredProc
+        |  @{QueryResults} =  |  Call Stored Procedure With Return  |  ${SPName}  |  ${ParamList}
+        |  Log Many  |  ${QueryResults}
+        """
+        cur = None
+        try:
+            cur = self._dbconnection.cursor(as_dict=False)
+            spName = spName.encode('ascii', 'ignore')
+            logger.info ('Executing : Call Stored Procedure With Return  |  %s  |  %s ' % (spName, spParams))
+            #retVal = cur.callproc(spName, (spParams))
+            cur.callproc(spName, (spParams))
+            #cur.nextset()
+            #self._dbconnection.commit()
+            #logger.info ('retVal is  %s ' % (retVal))
+            retVal=list()
+            for row in cur:
+                #logger.info ( ' %s ' % (row))
+                retVal.append(row)
+            return retVal
+        finally :
+            if cur :
+                self._dbconnection.rollback()
+
     def __execute_sql(self, cur, sqlStatement):
-        #logger.info("Executing : %s" % sqlStatement)
         return cur.execute(sqlStatement)

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -268,6 +268,22 @@ class Query(object):
             if cur:
                 self._dbconnection.rollback()
 
+    def call_stored_procedure(self, spName, spParams):
+        """
+        Uses the inputs of `spName` and 'spParams' to call a stored procedure
+        """
+        cur = None
+        try:
+            cur = self._dbconnection.cursor()
+            spName = spName.encode('ascii', 'ignore')
+            logger.info ('Executing : Query  |  %s  |  %s ' % (spName, spParams))
+            allRows = cur.callproc(spName, (spParams))
+            self._dbconnection.commit()
+            return allRows
+        finally :
+            if cur :
+                self._dbconnection.rollback()
+
     def __execute_sql(self, cur, sqlStatement):
         #logger.info("Executing : %s" % sqlStatement)
         return cur.execute(sqlStatement)

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -282,6 +282,14 @@ class Query(object):
         |  Set Test Variable  |  ${SPName} =   |  DBTest.DBSchema.MyStoredProc
         |  @{QueryResults} =  |  Call Stored Procedure  |  ${SPName}  |  ${ParamList}
         |  Log List  |  @{QueryResults}
+
+        Note: that the spParams is required to be passed in right now, even if it just an empty list.  In the following
+        example, the Stored Procedure does not accept any parameters.
+
+        |  @{ParamList} =  |  Create List
+        |  @{QueryResults} =  |  Call Stored Procedure  |  DBTest.DBSchema.NoParamsStoredProc  |  ${ParamList}
+        |  Log List  |  @{QueryResults}
+
         """
         cur = None
         try:

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -287,9 +287,11 @@ class Query(object):
         try:
             cur = self._dbconnection.cursor(as_dict=True)
             spName = spName.encode('ascii', 'ignore')
-            logger.info ('Executing : Query  |  %s  |  %s ' % (spName, spParams))
+            logger.info ('Executing : Call Stored Procedure  |  %s  |  %s ' % (spName, spParams))
+            #retVal = cur.callproc(spName, (spParams))
             cur.callproc(spName, (spParams))
-            retVal = self._dbconnection.commit()
+            retVal = cur.nextset()
+            self._dbconnection.commit()
             return retVal
         finally :
             if cur :


### PR DESCRIPTION
This adds a Call Store Procedure keyword based on the DB API 2 spec ".callproc".  Stored procedures can be called passing in parameters or not and getting a list returned.  This should resolve issue #20