### PR TITLE
Add support for `pypyodbc`

### DIFF
--- a/src/DatabaseLibrary/connection_manager.py
+++ b/src/DatabaseLibrary/connection_manager.py
@@ -87,7 +87,7 @@ class ConnectionManager(object):
             dbPort = dbPort or 5432
             logger.info ('Connecting using : %s.connect(database=%s, user=%s, password=%s, host=%s, port=%s) ' % (dbapiModuleName, dbName, dbUsername, dbPassword, dbHost, dbPort))
             self._dbconnection = db_api_2.connect (database=dbName, user=dbUsername, password=dbPassword, host=dbHost, port=dbPort)
-        elif dbapiModuleName in ["pyodbc"]:
+        elif dbapiModuleName in ["pyodbc", "pypyodbc"]:
             dbPort = dbPort or 1433
             logger.info ('Connecting using : %s.connect(DRIVER={SQL Server};SERVER=%s,%s;DATABASE=%s;UID=%s;PWD=%s)' % (dbapiModuleName,dbHost,dbPort,dbName,dbUsername, dbPassword))
             self._dbconnection = db_api_2.connect('DRIVER={SQL Server};SERVER=%s,%s;DATABASE=%s;UID=%s;PWD=%s' % (dbHost,dbPort,dbName,dbUsername,dbPassword))


### PR DESCRIPTION
Adding just a few characters will allow support of `pypyodbc` instead of just `pyodbc`.

[PyPyODBC](https://github.com/jiangwen365/pypyodbc) is a pure Python version of [PyODBC](https://mkleehammer.github.io/pyodbc/). For those of us who have to maintain disparate environments and platforms, staying with _pure Python_ helps in deployment and compatibility.

I've tested this on my machine, and the addition of `, "pypyodbc"` to line 90 allows the library to support this DB API driver.