### PR TITLE
fix call_stored_procedure to work with Oracle

### DIFF
--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -324,7 +324,10 @@ class Query(object):
             spParams = []
         cur = None
         try:
-            cur = self._dbconnection.cursor(as_dict=False)
+            if self.db_api_module_name in ["cx_Oracle"]:
+                cur = self._dbconnection.cursor()
+            else:
+                cur = self._dbconnection.cursor(as_dict=False)
             spName = spName.encode('ascii', 'ignore')
             logger.info('Executing : Call Stored Procedure  |  %s  |  %s ' % (spName, spParams))
             cur.callproc(spName, spParams)


### PR DESCRIPTION
`as_dict` is not a supported parameter for `cursor()` in cx_Oracle. I guess the list could be expanded to other RDBMSs in the future