### PR TITLE
Add an auto commit method to the database connection

### DIFF
--- a/src/DatabaseLibrary/connection_manager.py
+++ b/src/DatabaseLibrary/connection_manager.py
@@ -133,3 +133,23 @@ class ConnectionManager(object):
         """
         logger.info('Executing : Disconnect From Database')
         self._dbconnection.close()
+
+    def set_auto_commit(self, autoCommit=True):
+        """
+        Turn the autocommit on the database connection ON or OFF. 
+
+        The default behaviour on a newly created database connection is to automatically start a 
+        transaction, which means that database actions that won't work if there is an active 
+        transaction will fail. Common examples of these actions are creating or deleting a database 
+        or database snapshot. By turning on auto commit on the database connection these actions 
+        can be performed.
+
+        Example:
+        | # Default behaviour, sets auto commit to true
+        | Set Auto Commit
+
+        | # Explicitly set the desired state
+        | Set Auto Commit | False
+        """
+        logger.info('Executing : Set Auto Commit')
+        self._dbconnection.autocommit = autoCommit


### PR DESCRIPTION
With the current database connection logic it's not possible to use the database library to create or remove database snapshots, which can be useful to manage the state of a test database. By adding an "auto-commit" method to the connection logic this does become possible.