### PR TITLE
Do not mask errors in query.execute_sql_string

### DIFF
--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -299,6 +299,7 @@ class Query(object):
         Using optional `sansTran` to run command without an explicit transaction commit or rollback:
         | Execute Sql String | DELETE FROM person_employee_table; DELETE FROM person_table | True |
         """
+        cur = None
         try:
             cur = self._dbconnection.cursor()
             logger.info('Executing : Execute SQL String  |  %s ' % sqlString)


### PR DESCRIPTION
Initialize `cur` to `None`, otherwise `execute_sql_string` `finally` case fails and masks original exception.