### PR TITLE
Make Execute SQL keywords return number of rows affected

### DIFF
--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -196,9 +196,11 @@ class Query(object):
 
     def execute_sql_script(self, sqlScriptFileName, sansTran=False):
         """
-        Executes the content of the `sqlScriptFileName` as SQL commands. Useful for setting the database to a known
-        state before running your tests, or clearing out your test data after running each a test. Set optional input
-        `sansTran` to True to run command without an explicit transaction commit or rollback.
+        Executes the content of the `sqlScriptFileName` as SQL commands and
+        returns number of rows affected. Useful for setting the database to
+        a known state before running your tests, or clearing out your test
+        data after running each a test. Set optional input `sansTran` to
+        True to run command without an explicit transaction commit or rollback.
 
         Sample usage :
         | Execute Sql Script | ${EXECDIR}${/}resources${/}DDL-setup.sql |
@@ -251,6 +253,7 @@ class Query(object):
         sqlScriptFile = open(sqlScriptFileName)
 
         cur = None
+        result = 0
         try:
             cur = self._dbconnection.cursor()
             logger.info('Executing : Execute SQL Script  |  %s ' % sqlScriptFileName)
@@ -276,12 +279,12 @@ class Query(object):
 
                         sqlStatement += sqlFragment + ' '
 
-                        self.__execute_sql(cur, sqlStatement)
+                        result = result + self.__execute_sql(cur, sqlStatement)
                         sqlStatement = ''
 
             sqlStatement = sqlStatement.strip()
             if len(sqlStatement) != 0:
-                self.__execute_sql(cur, sqlStatement)
+                result = self.__execute_sql(cur, sqlStatement)
 
             if not sansTran:
                 self._dbconnection.commit()
@@ -289,11 +292,14 @@ class Query(object):
             if cur:
                 if not sansTran:
                     self._dbconnection.rollback()
+        return result
 
     def execute_sql_string(self, sqlString, sansTran=False):
         """
-        Executes the sqlString as SQL commands. Useful to pass arguments to your sql. Set optional input `sansTran` to
-        True to run command without an explicit transaction commit or rollback.
+        Executes the sqlString as SQL commands  and returns number of rows
+        affected. Useful to pass arguments to your sql. Set optional input
+        `sansTran` to True to run command without an explicit transaction
+        commit or rollback.
 
         SQL commands are expected to be delimited by a semi-colon (';').
 
@@ -307,16 +313,18 @@ class Query(object):
         | Execute Sql String | DELETE FROM person_employee_table; DELETE FROM person_table | True |
         """
         cur = None
+        result = 0
         try:
             cur = self._dbconnection.cursor()
             logger.info('Executing : Execute SQL String  |  %s ' % sqlString)
-            self.__execute_sql(cur, sqlString)
+            result = self.__execute_sql(cur, sqlString)
             if not sansTran:
                 self._dbconnection.commit()
         finally:
             if cur:
                 if not sansTran:
                     self._dbconnection.rollback()
+        return result
 
     def call_stored_procedure(self, spName, spParams=None, sansTran=False):
         """

--- a/test/DB2SQL_DB_Tests.robot
+++ b/test/DB2SQL_DB_Tests.robot
@@ -8,18 +8,18 @@ Library           DatabaseLibrary
 Create person table
     ${output} =    Execute SQL String    CREATE TABLE person (id decimal(10,0),first_name varchar(30),last_name varchar(30));
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Execute SQL Script - Insert Data person table
     Comment    ${output} =    Execute SQL Script    ./my_db_test_insertData.sql
     ${output} =    Execute SQL Script    ../test/my_db_test_insertData.sql
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    2
 
 Execute SQL String - Create Table
     ${output} =    Execute SQL String    create table foobar (id integer , firstname varchar(20) )
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Check If Exists In DB - Franz Allan
     Check If Exists In Database    SELECT id FROM person WHERE first_name = 'Franz Allan';
@@ -81,7 +81,7 @@ Verify Query - Get results as a list of dictionaries
 Insert Data Into Table foobar
     ${output} =    Execute SQL String    INSERT INTO foobar VALUES(1,'Jerry');
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify Query - Row Count foobar table 1 row
     ${output} =    Query    SELECT COUNT(*) FROM foobar;

--- a/test/MSSQL_DB_Tests.robot
+++ b/test/MSSQL_DB_Tests.robot
@@ -16,19 +16,19 @@ Create person table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    CREATE TABLE person (id integer unique, first_name varchar(20), last_name varchar(20));
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Execute SQL Script - Insert Data person table
     [Tags]    db    smoke
     ${output} =    Execute SQL Script    ./my_db_test_insertData.sql
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    2
 
 Execute SQL String - Create Table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    create table foobar (id integer primary key, firstname varchar(20) unique)
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Check If Exists In DB - Franz Allan
     [Tags]    db    smoke
@@ -125,13 +125,13 @@ Verify Execute SQL String - Row Count foobar table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SELECT COUNT(*) FROM foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Insert Data Into Table foobar
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO foobar VALUES(1,'Jerry');
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify Query - Row Count foobar table 1 row
     [Tags]    db    smoke
@@ -152,13 +152,13 @@ Begin first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SAVE TRANSACTION first    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Add person in first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO person VALUES(101,'Bilbo','Baggins');    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify person in first transaction
     [Tags]    db    smoke
@@ -204,7 +204,7 @@ Drop person and foobar tables
     [Tags]    db    smoke
     ${output} =    Execute SQL String    DROP TABLE IF EXISTS person;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
     ${output} =    Execute SQL String    DROP TABLE IF EXISTS foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0

--- a/test/MySQL_DB_Tests.robot
+++ b/test/MySQL_DB_Tests.robot
@@ -16,20 +16,20 @@ Create person table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    CREATE TABLE person (id integer unique,first_name varchar(20),last_name varchar(20));
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Execute SQL Script - Insert Data person table
     [Tags]    db    smoke
     Comment    ${output} =    Execute SQL Script    ./${DBName}_insertData.sql
     ${output} =    Execute SQL Script    ./my_db_test_insertData.sql
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    2
 
 Execute SQL String - Create Table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    create table foobar (id integer primary key, firstname varchar(20) unique)
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Check If Exists In DB - Franz Allan
     [Tags]    db    smoke
@@ -69,7 +69,7 @@ Retrieve records from person table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SELECT * FROM person;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    2
 
 Verify person Description
     [Tags]    db    smoke
@@ -120,19 +120,19 @@ Verify Execute SQL String - Row Count person table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SELECT COUNT(*) FROM person;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify Execute SQL String - Row Count foobar table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SELECT COUNT(*) FROM foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Insert Data Into Table foobar
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO foobar VALUES(1,'Jerry');
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify Query - Row Count foobar table 1 row
     [Tags]    db    smoke
@@ -156,13 +156,13 @@ Begin first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SAVEPOINT first    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Add person in first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO person VALUES(101,'Bilbo','Baggins');    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify person in first transaction
     [Tags]    db    smoke
@@ -172,13 +172,13 @@ Begin second transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SAVEPOINT second    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Add person in second transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO person VALUES(102,'Frodo','Baggins');    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify persons in first and second transactions
     [Tags]    db    smoke
@@ -188,7 +188,7 @@ Rollback second transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    ROLLBACK TO SAVEPOINT second    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Verify second transaction rollback
     [Tags]    db    smoke
@@ -198,7 +198,7 @@ Rollback first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    ROLLBACK TO SAVEPOINT first    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Verify first transaction rollback
     [Tags]    db    smoke
@@ -208,4 +208,4 @@ Drop person and foobar tables
     [Tags]    db    smoke
     ${output} =    Execute SQL String    DROP TABLE IF EXISTS person,foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0

--- a/test/PostgreSQL_DB_Tests.robot
+++ b/test/PostgreSQL_DB_Tests.robot
@@ -16,18 +16,18 @@ ${DBUser}         postgres
 Create person table
     ${output} =    Execute SQL String    CREATE TABLE person (id integer unique,first_name varchar,last_name varchar);
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Execute SQL Script - Insert Data person table
     Comment    ${output} =    Execute SQL Script    ./${DBName}_insertData.sql
     ${output} =    Execute SQL Script    ./my_db_test_insertData.sql
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    2
 
 Execute SQL String - Create Table
     ${output} =    Execute SQL String    create table foobar (id integer primary key, firstname varchar unique)
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Check If Exists In DB - Franz Allan
     Check If Exists In Database    SELECT id FROM person WHERE first_name = 'Franz Allan';
@@ -117,12 +117,12 @@ Verify Execute SQL String - Row Count person table
 Verify Execute SQL String - Row Count foobar table
     ${output} =    Execute SQL String    SELECT COUNT(*) FROM foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Insert Data Into Table foobar
     ${output} =    Execute SQL String    INSERT INTO foobar VALUES(1,'Jerry');
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify Query - Row Count foobar table 1 row
     ${output} =    Query    SELECT COUNT(*) FROM foobar;
@@ -145,4 +145,4 @@ Verify Query - Row Count foobar table 0 row
 Drop person and foobar tables
     ${output} =    Execute SQL String    DROP TABLE IF EXISTS person,foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0

--- a/test/SQLite3_DB_Tests.robot
+++ b/test/SQLite3_DB_Tests.robot
@@ -22,19 +22,19 @@ Create person table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    CREATE TABLE person (id integer unique,first_name varchar,last_name varchar);
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Execute SQL Script - Insert Data person table
     [Tags]    db    smoke
     ${output} =    Execute SQL Script    ./${DBName}_insertData.sql
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    2
 
 Execute SQL String - Create Table
     [Tags]    db    smoke
     ${output} =    Execute SQL String    create table foobar (id integer primary key, firstname varchar unique)
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Check If Exists In DB - Franz Allan
     [Tags]    db    smoke
@@ -137,7 +137,7 @@ Insert Data Into Table foobar
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO foobar VALUES(1,'Jerry');
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify Query - Row Count foobar table 1 row
     [Tags]    db    smoke
@@ -158,13 +158,13 @@ Begin first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SAVEPOINT first    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Add person in first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO person VALUES(101,'Bilbo','Baggins');    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify person in first transaction
     [Tags]    db    smoke
@@ -174,13 +174,13 @@ Begin second transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    SAVEPOINT second    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Add person in second transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    INSERT INTO person VALUES(102,'Frodo','Baggins');    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    1
 
 Verify persons in first and second transactions
     [Tags]    db    smoke
@@ -200,7 +200,7 @@ Rollback first transaction
     [Tags]    db    smoke
     ${output} =    Execute SQL String    ROLLBACK TO SAVEPOINT first    True
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
 
 Verify first transaction rollback
     [Tags]    db    smoke
@@ -210,7 +210,7 @@ Drop person and foobar tables
     [Tags]    db    smoke
     ${output} =    Execute SQL String    DROP TABLE IF EXISTS person;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0
     ${output} =    Execute SQL String    DROP TABLE IF EXISTS foobar;
     Log    ${output}
-    Should Be Equal As Strings    ${output}    None
+    Should Be Equal As Strings    ${output}    0


### PR DESCRIPTION
This is a proposed fix for #104.

I was able to run tests only against MySQL database and I tried to update other database tests as best as I could. I am sure I missed something, though. I would like to get feedback on other databases before this is merged.