### PR TITLE
If statement added in disconnect_from_database

### DIFF
--- a/src/DatabaseLibrary/connection_manager.py
+++ b/src/DatabaseLibrary/connection_manager.py
@@ -178,7 +178,10 @@ class ConnectionManager(object):
         | Disconnect From Database | # disconnects from current connection to the database |
         """
         logger.info('Executing : Disconnect From Database')
-        self._dbconnection.close()
+        if self._dbconnection==None:
+            return 'No open connection to close'
+        else:
+            self._dbconnection.close()
 
     def set_auto_commit(self, autoCommit=True):
         """


### PR DESCRIPTION
When using 'Disconnect from Database' in a Suite Teardown, while no connection was created because of an early error in the TC. The shown message is not really tidy; "AttributeError: 'NoneType' object has no attribute 'close'" and the Teardown Fails. 
Therefore I created a simple If Else statement that if no connection is open this will be returned as a message and the Teardown wil not fail.